### PR TITLE
Fix duplicated OMX.qcom.audio.decoder.aac entry

### DIFF
--- a/mm-core/src/8084/qc_registry_table.c
+++ b/mm-core/src/8084/qc_registry_table.c
@@ -440,22 +440,6 @@ omx_core_cb_type core[] =
       "audio_encoder.amrnb"
     }
   },
- {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL,
-      NULL,
-      NULL,
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
   {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function

--- a/mm-core/src/8084/qc_registry_table_android.c
+++ b/mm-core/src/8084/qc_registry_table_android.c
@@ -488,22 +488,6 @@ omx_core_cb_type core[] =
     }
   },
  {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL,
-      NULL,
-      NULL,
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
- {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function
     // Unique instance handle

--- a/mm-core/src/8226/qc_registry_table.c
+++ b/mm-core/src/8226/qc_registry_table.c
@@ -391,19 +391,6 @@ omx_core_cb_type core[] =
       "audio_encoder.amrnb"
     }
   },
- {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
   {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function

--- a/mm-core/src/8226/qc_registry_table_android.c
+++ b/mm-core/src/8226/qc_registry_table_android.c
@@ -431,19 +431,6 @@ omx_core_cb_type core[] =
     }
   },
  {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
- {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function
     // Unique instance handle

--- a/mm-core/src/8610/qc_registry_table.c
+++ b/mm-core/src/8610/qc_registry_table.c
@@ -404,19 +404,6 @@ omx_core_cb_type core[] =
       "audio_encoder.amrnb"
     }
   },
- {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
   {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function

--- a/mm-core/src/8610/qc_registry_table_android.c
+++ b/mm-core/src/8610/qc_registry_table_android.c
@@ -405,19 +405,6 @@ omx_core_cb_type core[] =
     }
   },
  {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
- {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function
     // Unique instance handle

--- a/mm-core/src/8974/qc_registry_table.c
+++ b/mm-core/src/8974/qc_registry_table.c
@@ -404,19 +404,6 @@ omx_core_cb_type core[] =
      "audio_decoder.awbplus"
     }
   },
- {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
   {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function

--- a/mm-core/src/8974/qc_registry_table_android.c
+++ b/mm-core/src/8974/qc_registry_table_android.c
@@ -456,19 +456,6 @@ omx_core_cb_type core[] =
     }
   },
  {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
- {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function
     // Unique instance handle

--- a/mm-core/src/msm8992/registry_table.c
+++ b/mm-core/src/msm8992/registry_table.c
@@ -456,22 +456,6 @@ omx_core_cb_type core[] =
       "audio_encoder.amrnb"
     }
   },
- {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL,
-      NULL,
-      NULL,
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
   {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function

--- a/mm-core/src/msm8992/registry_table_android.c
+++ b/mm-core/src/msm8992/registry_table_android.c
@@ -568,22 +568,6 @@ omx_core_cb_type core[] =
     }
   },
  {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL,
-      NULL,
-      NULL,
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
- {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function
     // Unique instance handle

--- a/mm-core/src/msm8994/registry_table.c
+++ b/mm-core/src/msm8994/registry_table.c
@@ -440,22 +440,6 @@ omx_core_cb_type core[] =
       "audio_encoder.amrnb"
     }
   },
- {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL,
-      NULL,
-      NULL,
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
   {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function

--- a/mm-core/src/msm8994/registry_table_android.c
+++ b/mm-core/src/msm8994/registry_table_android.c
@@ -584,22 +584,6 @@ omx_core_cb_type core[] =
     }
   },
  {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL,
-      NULL,
-      NULL,
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
- {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function
     // Unique instance handle

--- a/mm-core/src/plutonium/registry_table.c
+++ b/mm-core/src/plutonium/registry_table.c
@@ -440,22 +440,6 @@ omx_core_cb_type core[] =
       "audio_encoder.amrnb"
     }
   },
- {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL,
-      NULL,
-      NULL,
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
   {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function

--- a/mm-core/src/plutonium/registry_table_android.c
+++ b/mm-core/src/plutonium/registry_table_android.c
@@ -504,22 +504,6 @@ omx_core_cb_type core[] =
     }
   },
  {
-    "OMX.qcom.audio.decoder.aac",
-    NULL,   // Create instance function
-    // Unique instance handle
-    {
-      NULL,
-      NULL,
-      NULL,
-      NULL
-    },
-    NULL,   // Shared object library handle
-    "libOmxAacDec.so",
-    {
-      "audio_decoder.aac"
-    }
-  },
- {
     "OMX.qcom.audio.decoder.multiaac",
     NULL,   // Create instance function
     // Unique instance handle


### PR DESCRIPTION
There are duplcated aac audio decoder entry in the OMX table.
This fixes:
E OMXMaster: A component of name 'OMX.qcom.audio.decoder.aac' already exists, ignoring this one.

Change-Id: I09b8ae911659b8146c6c42f4b8b130a610fab391
